### PR TITLE
no longer include the test folder in the build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 # CHANGES
+## [1.0.7] - 2024-09-19
+- test folder removed, was being flagged in security analysis code
+
 ## [1.0.6] - 2024-09-19
 - fix logo reference
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ___
 |-------------|----------|--------------------------------|
 | poetry-core | 1.9.0    | build system                   |
 
-All tooling is defined in the `pyporject.toml` and managed using [poetry](https://pypi.org/project/poetry/) as follows:
+All tooling is defined in the `pyproject.toml` and managed using [poetry](https://pypi.org/project/poetry/) as follows:
 ```shell
 poetry install --with tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,11 @@ Repository = "https://github.com/bp100a/serial-usbipclient"
 name = "serial-usbipclient"
 authors = ["Harry J. Collins <bp100a@gmail.com>"]
 maintainers = ["Harry J. Collins <bp100a@gmail.com>"]
-version = "1.0.6"
+version = "1.0.7"
 description = "Simple serial connectivity to CDC (serial) USB devices exposed by a USBIPD service."
 readme = "README.md"
 package-mode = true
+exclude = ["**/tests/**/*"]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
- [x] Executed `isort, mypy, pylint, radon/xenon` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

remove `tests` folder from the distribution.